### PR TITLE
fix: typing TCXExcercise.trackpoints

### DIFF
--- a/tcxreader/tcx_exercise.py
+++ b/tcxreader/tcx_exercise.py
@@ -39,7 +39,7 @@ class TCXExercise:
 
         """
 
-        self.trackpoints:TCXTrackPoint = trackpoints
+        self.trackpoints:List[TCXTrackPoint] = trackpoints
         self.laps:List[TCXLap] = laps
         self.activity_type:str = activity_type
         self.calories = calories


### PR DESCRIPTION
A tiny PR which fixes typing of `TCXExercise.trackpoints`, which should be a `List`.

Having the wrong type here can lead to warnings on correct user code in IDEs which use type hints to check code.