### PR TITLE
Fix type annotation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ from tcxreader.tcxreader import TCXReader, TCXTrackPoint
 tcx_reader = TCXReader()
 file_location = 'example_data/cross-country-skiing_activity_1.tcx'
 
-data: TCXTrackPoint = tcx_reader.read(file_location)
+data: TCXExercise = tcx_reader.read(file_location)
 """ Example output:
 data = {TCXExercise}
  activity_type = {str} 'Other'


### PR DESCRIPTION
There is an inconsistency in the type annotation for the `tcx_reader.read()` method. I've fixed that.